### PR TITLE
Set the event release preference for new calendars to immediate

### DIFF
--- a/src/UNL/UCBCN/Calendar.php
+++ b/src/UNL/UCBCN/Calendar.php
@@ -59,6 +59,10 @@ class Calendar extends Record
     const STATUS_POSTED   = 'posted';
     const STATUS_ARCHIVED = 'archived';
     
+    const EVENT_RELEASE_PREFERENCE_DEFAULT   = null;
+    const EVENT_RELEASE_PREFERENCE_IMMEDIATE = 1;
+    const EVENT_RELEASE_PREFERENCE_PENDING   = 0;
+    
     public static function getTable()
     {
         return 'calendar';

--- a/src/UNL/UCBCN/Event.php
+++ b/src/UNL/UCBCN/Event.php
@@ -304,7 +304,7 @@ class Event extends Record
         $result = parent::insert();
 
         $status_for_new_event = 'pending';
-        if ($calendar->eventreleasepreference == 1) {
+        if ($calendar->eventreleasepreference == Calendar::EVENT_RELEASE_PREFERENCE_IMMEDIATE) {
             $status_for_new_event = 'posted';
         }
 

--- a/src/UNL/UCBCN/Manager/CreateCalendar.php
+++ b/src/UNL/UCBCN/Manager/CreateCalendar.php
@@ -29,6 +29,7 @@ class CreateCalendar extends PostHandler
         } else {
             # we are creating a new calendar
             $this->calendar = new Calendar;
+            $this->calendar->eventreleasepreference = Calendar::EVENT_RELEASE_PREFERENCE_IMMEDIATE;
         }
     }
 

--- a/src/UNL/UCBCN/Manager/CreateCalendar.php
+++ b/src/UNL/UCBCN/Manager/CreateCalendar.php
@@ -69,16 +69,16 @@ class CreateCalendar extends PostHandler
         $this->calendar->website = $post_data['website'];
         switch ($post_data['event_release_preference']) {
             case '':
-                $this->calendar->eventreleasepreference = NULL;
+                $this->calendar->eventreleasepreference = Calendar::EVENT_RELEASE_PREFERENCE_DEFAULT;
                 break;
             case 'immediate':
-                $this->calendar->eventreleasepreference = 1;
+                $this->calendar->eventreleasepreference = Calendar::EVENT_RELEASE_PREFERENCE_IMMEDIATE;
                 break;
             case 'pending':
-                $this->calendar->eventreleasepreference = 0;
+                $this->calendar->eventreleasepreference = Calendar::EVENT_RELEASE_PREFERENCE_PENDING;
                 break;
             default:
-                $this->calendar->eventreleasepreference = NULL;
+                $this->calendar->eventreleasepreference = Calendar::EVENT_RELEASE_PREFERENCE_DEFAULT;
         }
 
         $this->calendar->emaillists = $post_data['email_lists'];

--- a/www/templates/default/html/manager/CreateCalendar.tpl.php
+++ b/www/templates/default/html/manager/CreateCalendar.tpl.php
@@ -30,9 +30,9 @@
 
     <label for="event-release-preference">Event Release Preference</label>
     <select tabindex="4" id="event-release-preference" name="event_release_preference">
-        <option value="" <?php if ($context->calendar->getRawObject()->eventreleasepreference === NULL) echo 'selected="selected"' ?>></option>
-        <option value="immediate" <?php if ($context->calendar->getRawObject()->eventreleasepreference == 1) echo 'selected="selected"' ?>>Immediate</option>
-        <option value="pending" <?php if ($context->calendar->getRawObject()->eventreleasepreference === '0') echo 'selected="selected"' ?>>Pending</option>
+        <option value="" <?php if ($context->calendar->getRawObject()->eventreleasepreference === \UNL\UCBCN\Calendar::EVENT_RELEASE_PREFERENCE_DEFAULT) echo 'selected="selected"' ?>></option>
+        <option value="immediate" <?php if ($context->calendar->getRawObject()->eventreleasepreference == \UNL\UCBCN\Calendar::EVENT_RELEASE_PREFERENCE_IMMEDIATE) echo 'selected="selected"' ?>>Immediate</option>
+        <option value="pending" <?php if ($context->calendar->getRawObject()->eventreleasepreference === (string)\UNL\UCBCN\Calendar::EVENT_RELEASE_PREFERENCE_PENDING) echo 'selected="selected"' ?>>Pending</option>
     </select>
 
     <label for="email-lists">Email Lists (separated by commas)</label>


### PR DESCRIPTION
Before the recent manager upgrade, events that were created would skip the pending list. The event would be posted right away.

Now, it goes to pending and has to approved first.  This adds an often unnecessary step to creating events.  This can also cause frustration.

The change stems from the old manager code not respecting the `Calendar::eventreleasepreference` setting. It would instead look at user permissions. See: https://github.com/unl/UNL_UCBCN_Manager/blob/master/src/UNL/UCBCN/Manager/EventForm.php#L112

If we found the problem earlier it might have been easier to fix. Now, it might cause more confusion to change the way things work once again. People have had time to adjust, and change their preferences. We should probably respect that.

This PR helps to reduce confusion for NEW calendars. It changes the default for NEW calendars to `immediate`.  I think it is a reasonable expectation that most people don't want to have to approve events that they just created.