### PR TITLE
Prevent recurring logic from running for events where the recurring type is 'none'

### DIFF
--- a/src/UNL/UCBCN/Event/Occurrence.php
+++ b/src/UNL/UCBCN/Event/Occurrence.php
@@ -49,6 +49,8 @@ class Occurrence extends Record
 
     const ONE_DAY = 86400;
     const ONE_WEEK = 604800;
+    
+    const RECURRING_TYPE_NONE = 'none';
 
     public static function getTable()
     {

--- a/src/UNL/UCBCN/Frontend/EventInstance.php
+++ b/src/UNL/UCBCN/Frontend/EventInstance.php
@@ -59,7 +59,7 @@ class EventInstance implements RoutableInterface
         }
         
         //Set the recurring date
-        if (isset($options['recurringdate_id'])) {
+        if (Occurrence::RECURRING_TYPE_NONE != $this->eventdatetime->recurringtype && isset($options['recurringdate_id'])) {
             //Set the recurring date by the id
             $this->recurringdate = RecurringDate::getByID($options['recurringdate_id']);
         } else if ($requestedDate != date('Y-m-d', strtotime($this->eventdatetime->starttime))) {


### PR DESCRIPTION
There appear to be some orphaned records in the recurringdate table, in which the eventdatetime record has the recurring type set to `none`. These recurringdate records have their start times set to `1969-12-31`.

I'm not sure where these orphaned records came from, perhaps @tlemburg could shed some light.