### PR TITLE
Fix edge case where for multiple listings of the same event in upcoming view

### DIFF
--- a/src/UNL/UCBCN/Frontend/Upcoming.php
+++ b/src/UNL/UCBCN/Frontend/Upcoming.php
@@ -78,7 +78,7 @@ class Upcoming extends EventListing implements RoutableInterface
                 FROM eventdatetime as e
                 INNER JOIN event ON e.event_id = event.id
                 INNER JOIN calendar_has_event ON calendar_has_event.event_id = event.id
-                LEFT JOIN recurringdate ON (recurringdate.event_id = event.id AND recurringdate.unlinked = 0)
+                LEFT JOIN recurringdate ON (recurringdate.event_datetime_id = e.id AND recurringdate.unlinked = 0)
                 WHERE
                     calendar_has_event.calendar_id = ' . (int)$this->calendar->id . '
                     AND (
@@ -86,8 +86,10 @@ class Upcoming extends EventListing implements RoutableInterface
                          OR calendar_has_event.status =\'archived\'
                     )
                     AND (
-                        e.starttime >= "'.date('Y-m-d', $timestamp).'"
-                        OR recurringdate.recurringdate >= "'.date('Y-m-d', $timestamp).'"
+                        IF (recurringdate.recurringdate IS NULL,
+                            e.starttime,
+                            recurringdate.recurringdate
+                        ) >=  "'.date('Y-m-d', $timestamp).'"
                     )
                 ORDER BY (
                         IF (recurringdate.recurringdate IS NULL,


### PR DESCRIPTION
Okay, story time folks.

The root of this issue is the addition, and use of the `recurringdate.event_datetime_id` field. The poor structure of the old database relied on a relationship of `recurringdate.event_id`.
So, for example, event 875 has two eventdatetime records:

1. 95397, startdate=2015-01-09 08:00:00, recurring date for the 2nd of each month
2. 104734, startdate=2015-12-09 08:00:00, no recurring date

Therefor, because the fronted’s upcoming view relied purely on the `recurringdate.event_id` field, both events were showing up with recurring dates.

The issue was compounded by the start date of 104734.

The start date of 104734 is set to '2015-12-09 08:00:00', but recurring events exist for previous months (because of the above bug), such as '2015-01-09 08:00:00'. Thus the event start is 'upcoming', even though its effective value is supposed to be 1/9/2015 because of the recurring date.

Therefor, in this specific edge case, events were showing up in the upcoming view that were in the past, and there were duplicate event dates.

This commit also goes a step further to better handle start dates of recurring vs non-recurring dates.

This commit also requires adding an index on the recurringdate.event_datetime_id field, otherwise the execution time will jump from .05 seconds to about 6 seconds (this change has already been made on production).