### PR TITLE
Evaluate past events and datetimes to sort upcoming/past

### DIFF
--- a/src/UNL/UCBCN/Event/Occurrence.php
+++ b/src/UNL/UCBCN/Event/Occurrence.php
@@ -126,6 +126,14 @@ class Occurrence extends Record
         ));
     }
 
+    public function getAllDates()
+    {
+        return new RecurringDates(array(
+            'event_datetime_id' => $this->id,
+            'with_ongoing' => true
+        ));
+    }
+
     public function deleteRecurrences()
     {
         $recurring_dates = $this->getRecurrences();

--- a/src/UNL/UCBCN/Event/RecurringDates.php
+++ b/src/UNL/UCBCN/Event/RecurringDates.php
@@ -40,9 +40,15 @@ class RecurringDates extends RecordList
                         'ORDER BY recurrence_id ASC;';
                 }
             } else {
-                return 'SELECT id FROM recurringdate WHERE ' .
-                    'event_datetime_id = ' . (int)($this->options['event_datetime_id']) . ' AND unlinked = 0 AND ongoing = 0 ' .
-                    'ORDER BY recurrence_id ASC;';
+                if (array_key_exists('with_ongoing', $this->options)) {
+                    return 'SELECT id FROM recurringdate WHERE ' .
+                        'event_datetime_id = ' . (int)($this->options['event_datetime_id']) . ' AND unlinked = 0 ' .
+                        'ORDER BY recurrence_id ASC;';
+                } else {
+                    return 'SELECT id FROM recurringdate WHERE ' .
+                        'event_datetime_id = ' . (int)($this->options['event_datetime_id']) . ' AND unlinked = 0 AND ongoing = 0 ' .
+                        'ORDER BY recurrence_id ASC;';
+                }
             }
         } else {
             return 'SELECT id FROM recurringdate WHERE ' .

--- a/src/UNL/UCBCN/Manager/Calendar.php
+++ b/src/UNL/UCBCN/Manager/Calendar.php
@@ -83,15 +83,24 @@ class Calendar {
     private function archiveEvents() {
         # find all posted (upcoming) events on the calendar
         $events = $this->calendar->getEvents('posted');
+        $archived_events = $this->calendar->getEvents('archived');
 
         # check each event to see if it has passed
         foreach ($events as $event) {
             # we will consider it passed if all datetimes are in the past
             $datetimes = $event->getDatetimes();
-            $archive = true;
+            $archive = TRUE;
             foreach ($datetimes as $datetime) {
+                $recurring_dates = $datetime->getAllDates();
+                foreach($recurring_dates as $recurring_date) {
+                    if ($recurring_date->recurringdate >= date('Y-m-d')) {
+                        $archive = FALSE;
+                        break;
+                    }
+                }
+
                 if ($datetime->starttime >= date('Y-m-d 00:00:00') || ($datetime->endtime != NULL && $datetime->endtime >= date('Y-m-d 00:00:00'))) {
-                    $archive = false;
+                    $archive = FALSE;
                     break;
                 }
             }
@@ -99,6 +108,32 @@ class Calendar {
             # update the status with the calendar
             if ($archive) {
                 $event->updateStatusWithCalendar($this->calendar, 'archived');
+            }
+        }
+
+        # check each past event to see if it is now current
+        foreach ($archived_events as $event) {
+            # we will consider it upcoming if any datetime is after today at midnight
+            $datetimes = $event->getDatetimes();
+            $move = FALSE;
+            foreach ($datetimes as $datetime) {
+                $recurring_dates = $datetime->getAllDates();
+                foreach($recurring_dates as $recurring_date) {
+                    if ($recurring_date->recurringdate >= date('Y-m-d')) {
+                        $move = TRUE;
+                        break;
+                    }
+                }
+
+                if ($datetime->starttime >= date('Y-m-d 00:00:00') || ($datetime->endtime != NULL && $datetime->endtime >= date('Y-m-d 00:00:00'))) {
+                    $move = TRUE;
+                    break;
+                }
+            }
+
+            # update the status with the calendar
+            if ($move) {
+                $event->updateStatusWithCalendar($this->calendar, 'posted');
             }
         }
     }

--- a/src/UNL/UCBCN/Manager/Calendar.php
+++ b/src/UNL/UCBCN/Manager/Calendar.php
@@ -82,8 +82,8 @@ class Calendar {
 
     private function archiveEvents() {
         # find all posted (upcoming) events on the calendar
-        $events = $this->calendar->getEvents('posted');
-        $archived_events = $this->calendar->getEvents('archived');
+        $events = $this->calendar->getEvents(CalendarModel::STATUS_POSTED);
+        $archived_events = $this->calendar->getEvents(CalendarModel::STATUS_ARCHIVED);
 
         # check each event to see if it has passed
         foreach ($events as $event) {
@@ -95,7 +95,7 @@ class Calendar {
                 foreach($recurring_dates as $recurring_date) {
                     if ($recurring_date->recurringdate >= date('Y-m-d')) {
                         $archive = FALSE;
-                        break;
+                        break 2;
                     }
                 }
 
@@ -107,7 +107,7 @@ class Calendar {
 
             # update the status with the calendar
             if ($archive) {
-                $event->updateStatusWithCalendar($this->calendar, 'archived');
+                $event->updateStatusWithCalendar($this->calendar, CalendarModel::STATUS_ARCHIVED);
             }
         }
 
@@ -121,7 +121,7 @@ class Calendar {
                 foreach($recurring_dates as $recurring_date) {
                     if ($recurring_date->recurringdate >= date('Y-m-d')) {
                         $move = TRUE;
-                        break;
+                        break 2;
                     }
                 }
 
@@ -133,7 +133,7 @@ class Calendar {
 
             # update the status with the calendar
             if ($move) {
-                $event->updateStatusWithCalendar($this->calendar, 'posted');
+                $event->updateStatusWithCalendar($this->calendar, CalendarModel::STATUS_POSTED);
             }
         }
     }


### PR DESCRIPTION
Previously, the Calendar page was only moving Upcoming Events to Past and not the other way around. Also the method to do this was only respecting the datetimes of the initial event, not any recurrences that were further out. This change causes the method to look at every date related to the event and put it in Past or Upcoming appropriately.

Fixes https://trello.com/c/1emrN1Ra/88-events-that-are-not-past-are-showing-up-in-past-wtf